### PR TITLE
Add Plausible analytics snippet to default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,7 @@
         integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
     <script src="{{ '/assets/js/respond.js' | relative_url }}"></script> -->
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <script defer data-domain="torlenor.org" src="https://plausible.blbr.app/js/script.js"></script>
 
     {% if site.google_analytics %}
       <script>


### PR DESCRIPTION
### Motivation
- Add Plausible analytics to the global site head so the site can report page metrics for `torlenor.org` via the manual-install snippet shown in the screenshot.

### Description
- Inserted the Plausible script tag (`<script defer data-domain="torlenor.org" src="https://plausible.blbr.app/js/script.js"></script>`) into the `<head>` of `_layouts/default.html` and committed the change.

### Testing
- Verified the edit with `git diff` showing the added script line; `bundle exec jekyll build` could not be executed because `jekyll` was not installed in this environment and `bundle install` failed due to upstream `rubygems.org` returning `403 "Forbidden"` while fetching gems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2fdee144832ab5f042b3961d8dd9)